### PR TITLE
Drop support for Node.js v10 and v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
+        cache: npm
     - name: Setup compilers
       if: startsWith(matrix.os, 'macos-')
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
         cache: npm
+    - uses: actions/cache@v1
+      with:
+        path: /home/runner/.cmake-js
+        key: ${{ matrix.node }}-cmake-js
     - name: Setup compilers
       if: startsWith(matrix.os, 'macos-')
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: ["^10.20.0", "^12.17.0", 14, 16]
+        node: [14, 16, 18]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v2.0.0 (UNRELEASED)
+
+- [breaking] Node.js v10 and v12 are no longer supported.
+
 ## v1.0.0 (2021-12-22)
 - Update libjsonnet to [v0.18.0](https://github.com/google/jsonnet/releases/tag/v0.18.0)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library is documented in the TypeScript type definitions at [`types/index.d.
 
 ## Installation Requirements
 
-- [Node.js with Node-API Version 6](https://nodejs.org/api/n-api.html#n_api_node_api_version_matrix): v10 (^10.20.0), v12 (^12.17.0), v14 or later
+- [Node.js](https://nodejs.org/) v14 or later
 - [GCC](https://gcc.gnu.org/projects/cxx-status.html#cxx17) or [Clang](https://clang.llvm.org/cxx_status.html#cxx17) C++ compiler that supports C++17
 - CMake 3.8 or later
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cmake-verbose": "cmake-js rebuild -l verbose --CDCMAKE_VERBOSE_MAKEFILE=1"
   },
   "engines": {
-    "node": "^10.20.0 || ^12.17.0 || >=14"
+    "node": ">=14"
   },
   "dependencies": {
     "bindings": "^1.5.0",

--- a/spec/example_spec.js
+++ b/spec/example_spec.js
@@ -9,7 +9,7 @@ const execFile = promisify(cp.execFile);
 const jsExamples = path.join(__dirname, "../examples/*.{mjs,cjs}");
 const tsExamples = path.join(__dirname, "../examples/*.ts");
 
-const timeout = 3000;
+const timeout = 10000;
 
 const nodeMajor = Number.parseInt(process.versions.node.split('.')[0]);
 if(nodeMajor >= 12) {


### PR DESCRIPTION
They are now EOL