### PR TITLE
Fix package.json "files" for npm@9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "/**/LICENSE",
     "/**/LICENSE.txt",
     "/*.md",
-    "/examples/*",
-    "/lib/*",
+    "/examples/",
+    "/lib/",
     "/types/*.d.ts",
-    "/src/*",
-    "/spec/*",
+    "/src/",
+    "/spec/",
     "/third_party/jsonnet/CMakeLists.txt.in",
     "/third_party/jsonnet/include/*.h",
     "/third_party/jsonnet/core/*.c",
@@ -51,7 +51,7 @@
     "/third_party/jsonnet/third_party/rapidyaml/rapidyaml/**/*.natvis",
     "/third_party/jsonnet/stdlib/*.cpp",
     "/third_party/jsonnet/stdlib/*.jsonnet",
-    "/third_party/jsonnet/test_suite/*"
+    "/third_party/jsonnet/test_suite/"
   ],
   "keywords": [
     "jsonnet",


### PR DESCRIPTION
npm@9 has an incompatibility around glob in files directive. https://github.com/npm/cli/issues/5918 suggets that glob was not necessary here.