### PR TITLE
node-addon-api@7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "cmake-js": "^7.0.0",
-        "node-addon-api": "^6.0.0"
+        "node-addon-api": "^7.0.0"
       },
       "devDependencies": {
         "@definitelytyped/dtslint": "^0.0.182",
@@ -3181,9 +3181,9 @@
       "dev": true
     },
     "node_modules/node-addon-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
-      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
     },
     "node_modules/node-api-headers": {
       "version": "0.0.1",
@@ -7130,9 +7130,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
-      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
     },
     "node-api-headers": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "cmake-js": "^7.0.0",
-    "node-addon-api": "^6.0.0"
+    "node-addon-api": "^7.0.0"
   },
   "devDependencies": {
     "@definitelytyped/dtslint": "^0.0.182",


### PR DESCRIPTION
node-addon-api@7 drops Node.js v14 support. Not affected by real incompatibilities.