### PR TITLE
package.json: Specify exports.*.types

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "./lib/index.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./lib/index.js",
       "default": "./lib/module.mjs"
     }


### PR DESCRIPTION
Some type checkers need it.

Fixes #383