### PR TITLE
Support CMake 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
       with:
         path: /home/runner/.cmake-js
         key: ${{ matrix.node }}-cmake-js
+    - name: Set git identity
+      run: |
+        git config --global user.email automate@hanazuki.dev
+        git config --global user.name automate
     - name: Setup compilers
       if: startsWith(matrix.os, 'macos-')
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## UNRELEASED
+- The package is now compatible with CMake 4.
+
 ## v3.0.0 (2025-05-08)
 - [breaking] Node.js v14, v16 and v18 are no longer supported.
 - Update libjsonnet to [v0.21.0](https://github.com/google/jsonnet/releases/tag/v0.21.0).

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "scripts": {
     "install": "cmake-js build --CDCMAKE_EXPORT_COMPILE_COMMANDS=1",
+    "prepare": "if test -f ./scripts/apply-patches.sh; then ./scripts/apply-patches.sh; fi",
     "test": "jasmine",
     "lint": "dtslint types",
     "format": "clang-format -i src/*",

--- a/patches/jsonnet/0001-Add-cmake4-to-cmake_minimum_required.patch
+++ b/patches/jsonnet/0001-Add-cmake4-to-cmake_minimum_required.patch
@@ -1,0 +1,42 @@
+From 6c87c1b0e1e18d25898be071c1b231e264f05a8c Mon Sep 17 00:00:00 2001
+From: Pat Riehecky <riehecky@fnal.gov>
+Date: Wed, 16 Jul 2025 08:58:46 -0500
+Subject: [PATCH] Add cmake4 to cmake_minimum_required.
+
+Leaving cmake 2.8 may have some long term cost, but for now
+it all works as expected.
+
+External projects will need to manage their own cmake_minimum_required.
+
+Signed-off-by: Pat Riehecky <riehecky@fnal.gov>
+---
+ CMakeLists.txt    | 2 +-
+ CMakeLists.txt.in | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dd17367b..3413ea14 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 2.8.7...4.0)
+ project(jsonnet C CXX)
+ 
+ include(ExternalProject)
+diff --git a/CMakeLists.txt.in b/CMakeLists.txt.in
+index 41fac662..7f7d802a 100644
+--- a/CMakeLists.txt.in
++++ b/CMakeLists.txt.in
+@@ -1,7 +1,7 @@
+ # CMake script run a generation-time. This must be separate from the main
+ # CMakeLists.txt file to allow downloading and building googletest at generation
+ # time.
+-cmake_minimum_required(VERSION 2.8.2)
++cmake_minimum_required(VERSION 2.8.2...4.0)
+ 
+ project(googletest-download NONE)
+ 
+-- 
+2.49.0
+

--- a/scripts/apply-patches.sh
+++ b/scripts/apply-patches.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eux
+
+git submodule update third_party/jsonnet
+for patch in patches/jsonnet/*; do
+  git -C third_party/jsonnet am <"$patch"
+done


### PR DESCRIPTION
This change makes the package buildable with CMake 4 by backporting a relevant upstream patch.

Fixes #371