### PR TITLE
Multiple variables assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- `Jsonnet.prototype.{extString,extCode,tlaString,tlaCode}` now accept an object to assign multiple variables at once.
+
 ## v3.1.1 (2026-04-02)
 
 - No changes since v3.1.0 -- v3.1.0 was not properly packaged during the release workflow.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,38 @@
 /*! SPDX-License-Identifier: MIT */
-const binding = require('bindings')('node-jsonnet')
+const binding = module.exports = require('bindings')('node-jsonnet')
 const { Jsonnet } = binding;
-const isAsyncFunction = require('util').types.isAsyncFunction;
+const { isAsyncFunction } = require('node:util').types;
+
+const proto = Jsonnet.prototype;
 
 // Workaround: Callback's throwing in ThreadSafeFunction kills Node VM.
 // Wrapping in async function can prevent it.
-
-const _nativeCallback = Jsonnet.prototype._nativeCallback;
-Jsonnet.prototype.nativeCallback = function(name, func, ...params) {
+const _nativeCallback = proto._nativeCallback;
+Object.defineProperty(proto, 'nativeCallback', {
+  value: function(name, func, ...params) {
   const asyncFunc = isAsyncFunction(func)
         ? func
         : async function(...args) { return func.call(this, ...args); }
 
   return _nativeCallback.call(this, name, asyncFunc, ...params);
+  },
+});
+
+// Accept an object as the sole argument when defining ext/tla.
+for(const func of ['extString', 'extCode', 'tlaString', 'tlaCode']) {
+  const origFunc = proto[`_${func}`];
+  Object.defineProperty(proto, func, {
+    value: function(...params) {
+      if(params.length == 1) {
+        for(const [key, value] of Object.entries(params[0])) {
+          origFunc.call(this, key, value);
+        }
+        return this;
+      } else {
+        return origFunc.call(this, ...params);
+      }
+    },
+  });
 }
 
 class JsonnetError extends Error {
@@ -23,6 +43,7 @@ class JsonnetError extends Error {
   }
 }
 
-Object.defineProperty(binding, 'JsonnetError', { value: JsonnetError });
-
-module.exports = binding;
+Object.defineProperty(binding, 'JsonnetError', {
+  value: JsonnetError,
+  enumerable: true,
+});

--- a/spec/binding_spec.js
+++ b/spec/binding_spec.js
@@ -49,6 +49,22 @@ describe('binding', () => {
     expect(j).toBeJSON("str2");
   });
 
+  it('supports multiple extVar assignment', async () => {
+    const jsonnet = new Jsonnet()
+      .extString({var1: "A", var2: "B"})
+      .extCode({var3: "{c: [0]}", var4: '"D"'});
+
+    let j = await jsonnet.evaluateSnippet(
+      `{a: std.extVar("var1"), b: std.extVar("var2"), c: std.extVar("var3"), d: std.extVar("var4")}`
+    );
+    expect(j).toBeJSON({
+      a: "A",
+      b: "B",
+      c: {c: [0]},
+      d: "D",
+    });
+  });
+
   it('can import files using Jpath', async () => {
     const jsonnet = new Jsonnet().addJpath(`${__dirname}/fixtures`);
 
@@ -103,6 +119,22 @@ describe('binding', () => {
 
     j = await jsonnet.evaluateSnippet(`function(var2, var1) var1 + var2.y`);
     expect(j).toBeJSON("test2");
+  });
+
+  it('supports multiple top-level arguments assignment', async () => {
+    const jsonnet = new Jsonnet()
+      .tlaString({var1: "A", var2: "B"})
+      .tlaCode({var3: "{c: [0]}", var4: '"D"'});
+
+    let j = await jsonnet.evaluateSnippet(
+      `function(var1, var2, var3, var4) {a: var1, b: var2, c: var3, d: var4}`
+    );
+    expect(j).toBeJSON({
+      a: "A",
+      b: "B",
+      c: {c: [0]},
+      d: "D",
+    });
   });
 
   it('support native callbacks', async () => {

--- a/src/Jsonnet.cpp
+++ b/src/Jsonnet.cpp
@@ -29,10 +29,10 @@ namespace nodejsonnet {
         InstanceMethod<&Jsonnet::evaluateSnippetMulti>("evaluateSnippetMulti"),
         InstanceMethod<&Jsonnet::evaluateFileStream>("evaluateFileStream"),
         InstanceMethod<&Jsonnet::evaluateSnippetStream>("evaluateSnippetStream"),
-        InstanceMethod<&Jsonnet::extString>("extString"),
-        InstanceMethod<&Jsonnet::extCode>("extCode"),
-        InstanceMethod<&Jsonnet::tlaString>("tlaString"),
-        InstanceMethod<&Jsonnet::tlaCode>("tlaCode"),
+        InstanceMethod<&Jsonnet::extString>("_extString"),
+        InstanceMethod<&Jsonnet::extCode>("_extCode"),
+        InstanceMethod<&Jsonnet::tlaString>("_tlaString"),
+        InstanceMethod<&Jsonnet::tlaCode>("_tlaCode"),
         InstanceMethod<&Jsonnet::addJpath>("addJpath"),
         InstanceMethod<&Jsonnet::nativeCallback>("_nativeCallback"),  // See also lib/index.js
       });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,6 +65,12 @@ export class Jsonnet {
    * @param value - String value to which the variable is bound
    */
   extString(key: string, value: string): this;
+  /**
+   * Binds multiple external variables to string values.
+   *
+   * @param vars - Mapping from variable names to their string values
+   */
+  extString(vars: Record<string, string>): this;
 
   /**
    * Binds external variable named as `key` to a value represented by `value`.
@@ -73,6 +79,12 @@ export class Jsonnet {
    * @param value - Code representation of the value to which the variable is bound
    */
   extCode(key: string, value: string): this;
+  /**
+   * Binds multiple external variables to values represented by code.
+   *
+   * @param vars - Mapping from variable names to their code representations
+   */
+  extCode(vars: Record<string, string>): this;
 
   /**
    * Binds top-level argument named as `key` to string `value`.
@@ -81,6 +93,12 @@ export class Jsonnet {
    * @param value - String value to which the argument is bound
    */
   tlaString(key: string, value: string): this;
+  /**
+   * Binds multiple top-level arguments to string values.
+   *
+   * @param vars - Mapping from argument names to their string values
+   */
+  tlaString(vars: Record<string, string>): this;
 
   /**
    * Binds top-level argument named as `key` to a value represented by `value`.
@@ -89,6 +107,12 @@ export class Jsonnet {
    * @param value - Code representation of the value to which the argument is bound
    */
   tlaCode(key: string, value: string): this;
+  /**
+   * Binds multiple top-level arguments to values represented by code.
+   *
+   * @param vars - Mapping from argument names to their code representations
+   */
+  tlaCode(vars: Record<string, string>): this;
 
   /**
    * Adds a path to the list of include paths. Paths added more recently take precedence.


### PR DESCRIPTION
`Jsonnet.prototype.{extString,extCode,tlaString,tlaCode}` now accept an object to assign multiple variables at once.