### PR TITLE
fix: initialize errorType to Generic in JsonnetWorker

### DIFF
--- a/src/JsonnetWorker.cpp
+++ b/src/JsonnetWorker.cpp
@@ -39,7 +39,7 @@ namespace nodejsonnet {
             .New({e.Get("message")});
       break;
     default:
-      abort();
+      abort(); // unreachable
     }
 
     deferred.Reject(e);

--- a/src/JsonnetWorker.hpp
+++ b/src/JsonnetWorker.hpp
@@ -80,7 +80,7 @@ namespace nodejsonnet {
     std::unique_ptr<Op> op;
     Napi::Promise::Deferred deferred;
     JsonnetVm::Buffer result;
-    ErrorType errorType;
+    ErrorType errorType = ErrorType::Generic;
   };
 
 }


### PR DESCRIPTION
errorType had no default initializer and was not set in the constructor, only assigned in the catch(JsonnetError) block inside Execute().  If any other exceptions escaped Execute() the switch in OnError() would read an indeterminate value, which is UB.