### PR TITLE
parseMultiValue: preserve __proto__ key in result object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Cyclic references in values returned from a native callback are now detected and reported as an exception, instead of crashing the VM with a stack overflow.
 - Native callbacks now honor `toJSON()` on returned values; values that are not serializable (functions, symbols) are omitted from objects or serialized as `null` in arrays, consistent with `JSON.stringify` semantics.
+- Fix: `evaluateSnippetMulti` and `evaluateFileMulti` now correctly preserve a file key named `__proto__` in the returned object (no security impact: the key was silently dropped rather than causing prototype pollution).
 
 ## v3.3.1 (2026-05-24)
 

--- a/spec/binding_spec.cjs
+++ b/spec/binding_spec.cjs
@@ -440,6 +440,14 @@ describe('binding', () => {
     });
   });
 
+  it('preserves __proto__ key in multi output', async () => {
+    const jsonnet = new Jsonnet();
+
+    const dict = await jsonnet.evaluateSnippetMulti(`{"__proto__": {v: 1}}`);
+    expect(Object.hasOwn(dict, '__proto__')).toBeTrue();
+    expect(dict['__proto__']).toBe('{\n   "v": 1\n}\n');
+  });
+
   it('reports error for evaluateSnippetMulti', async () => {
     const jsonnet = new Jsonnet();
 

--- a/src/JsonnetWorker.cpp
+++ b/src/JsonnetWorker.cpp
@@ -72,6 +72,7 @@ namespace nodejsonnet {
   namespace {
     Napi::Value parseMultiValue(Napi::Env env, JsonnetVm::Buffer buffer) {
       auto result = Napi::Object::New(env);
+      result.Set("__proto__", env.Null());  // TODO: Use node_api_set_prototype when stabilized.
 
       for(auto p = buffer.get(); *p;) {
         std::string_view const name(p);


### PR DESCRIPTION
Assigning a string value to __proto__ property was silently ignored.